### PR TITLE
feat: support custom date and time strftime strings

### DIFF
--- a/plugin.kdl
+++ b/plugin.kdl
@@ -9,6 +9,9 @@ layout {
             timezone5 "NPT/+5.75"
             // Testing that it will be in the specified timezone instead of timezone1
             default_timezone "JST"
+            // Specify custom format strings
+            date_format "%Y/%m/%d %A"
+            time_format "%I:%M %p"
             // Testing the Color Parser
             background_color "#0080a0"
             foreground_color "#ffffff"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ static DEFAULT_TEXT_ALIGN: &str = "right";
 pub struct Config {
     timezone: LinkedHashMap<String, f64>,
     default_timezone: String,
+    date_format: String,
+    time_format: String,
     background_color: (u8, u8, u8),
     foreground_color: (u8, u8, u8),
     pane_color: (u8, u8, u8),
@@ -33,6 +35,8 @@ impl Default for Config {
         Config {
             timezone,
             default_timezone: default_timezone.to_string(),
+            date_format: "%Y-%m-%d %a".to_string(),
+            time_format: "%H:%M".to_string(),
             background_color: parse_color(DEFAULT_BACKGROUND_COLOR).unwrap(),
             foreground_color: parse_color(DEFAULT_FOREGROUND_COLOR).unwrap(),
             pane_color: parse_color(DEFAULT_PANE_COLOR).unwrap(),
@@ -91,6 +95,14 @@ impl Config {
         }
     }
 
+    pub fn get_date_format(&self) -> &String {
+        &self.date_format
+    }
+
+    pub fn get_time_format(&self) -> &String {
+        &self.time_format
+    }
+
     pub fn get_background_color(&self) -> (u8, u8, u8) {
         self.background_color
     }
@@ -142,6 +154,12 @@ impl Config {
                 }
                 "default_timezone" => {
                     default_timezone = Some(value.trim().to_string());
+                }
+                "date_format" => {
+                    self.date_format = value.trim().to_string();
+                }
+                "time_format" => {
+                    self.time_format = value.trim().to_string();
                 }
                 "background_color" => {
                     if let Ok(color) = parse_color(value) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,18 +127,8 @@ impl ZellijPlugin for State {
 
     fn render(&mut self, _rows: usize, cols: usize) {
         if let Some(now) = self.now() {
-            let date = format!(
-                "{year}-{month:02}-{day:02} {weekday}",
-                year = now.year(),
-                month = now.month(),
-                day = now.day(),
-                weekday = now.weekday(),
-            );
-            let time = format!(
-                "{hour:02}:{minute:02}",
-                hour = now.hour(),
-                minute = now.minute(),
-            );
+            let date = now.format(self.config.get_date_format()).to_string();
+            let time = now.format(self.config.get_time_format()).to_string();
             print!("{}", self.line.create(cols, &self.timezone, &date, &time));
         }
     }


### PR DESCRIPTION
Add two fields
* `date_format` Adds a format string for the second position
* `time_format` Adds a format string for the third position

The test layout creates the following:
<img width="312" alt="Screenshot 2024-04-29 at 11 51 38 PM" src="https://github.com/h1romas4/zellij-datetime/assets/7676229/dc6bfbcc-2fc9-4946-b139-e1d9be7f03af">

IMO a better way would be to allow users to specify individual format strings for each section, i.e. 

```
    pane size=1 borderless=true {
        plugin location="..." {
            # or however you specify lists in KDL
            sections [ "%Z", "%Y/%m/%d %A", "%I:%M %p" ]
        }
    }
```

But the above method is not backwards compatible with users who are specifying `arrow_seperator` values